### PR TITLE
Fix for deadlock in logging

### DIFF
--- a/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/clientlauncher/ClientLogger.java
+++ b/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/clientlauncher/ClientLogger.java
@@ -21,7 +21,7 @@ public class ClientLogger {
 		
 		Handler handler = new StreamHandler(System.out, new SimpleFormatter()) {
 			@Override
-			public synchronized void publish(LogRecord record) {
+			public void publish(LogRecord record) {
 				
 				if (!CONSOLE_LOGGER.equals(record.getLoggerName())) {
 					try {


### PR DESCRIPTION
Deadlock is happening when 2 threads in the client try to log at the same time. Example thread dump here: https://gist.github.com/bdew/d6a2e1372dec8864403395ead8f7a2ac

Easiest way to reproduce is to pray right after you log in, if you're (un)lucky you'll get the 2 following lines emitted at the same time and your client will hang:

```
Writing to PlayerFiles\players\bdew\logs\_Skills.2018-04.txt
SEVERE: Input does not appear to be an Ogg bitstream.
```

Making this method non-synchronized seems to fix it, and i don't see any particular reason for it to be - it only accesses a thread local value and System.out.println which is synchronized on it's own (and that's part of why it deadlocks) - so i just left it at that.

Compiled build for testing here - https://www.dropbox.com/s/7xwwa43wi86mj91/client-modlauncher-0.8-hangfix.zip?dl=0