### PR TITLE
fix client lock up when trying to load missing cross-pack resources

### DIFF
--- a/modules/mods/serverpacks/src/main/java/org/gotti/wurmonline/clientmods/serverpacks/ServerPacksMod.java
+++ b/modules/mods/serverpacks/src/main/java/org/gotti/wurmonline/clientmods/serverpacks/ServerPacksMod.java
@@ -114,8 +114,11 @@ public class ServerPacksMod implements WurmClientMod, Initable, PreInitable, Con
 							"			int sep = $1.indexOf('/');\n" +
 							"           com.wurmonline.client.resources.Pack pack = com.wurmonline.client.WurmClientBase.getResourceManager()" +
 							"				.findPack(newFilename.substring(1,sep));" +
-							"           if (pack!=null)" +
-							"           	return new com.wurmonline.client.resources.PackResourceUrl(pack, $1.substring(sep+1));" +
+							"           if (pack!=null) {" +
+							"				com.wurmonline.client.resources.PackResourceUrl nurl = new com.wurmonline.client.resources.PackResourceUrl(pack, $1.substring(sep+1));" +
+							"				if (!nurl.exists()) throw com.wurmonline.client.GameCrashedException.forFailure(\"Derived cross-pack resource \" + nurl + \" does not exist (source \" + this + \")\");" +
+							"           	return nurl;" +
+							"			}" +
 							"		}");
 
 		} catch (NotFoundException | CannotCompileException e) {


### PR DESCRIPTION
This fixes and issue i found with #15 

When the client tries to load a resource from another pack and that resource doesn't exist it will hang the loading thread, and once enough of them are hanging lock up the client. This is exacerbated by the client trying to load a bump map for all the textures it loads by appending _n to their name... and many/most textures in graphics.jar don't actually have bump maps. 

The fix adds a check if a url actually exists and if not throws an exception like the original PackResourceUrl.derive()