### PR TITLE
Use https in maven pom.xml for gotti.no-ip.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 	<repositories>
 		<repository>
 			<id>gotti-no-ip-org-ssh-repository</id>
-			<url>http://gotti.no-ip.org/maven/repository</url>
+			<url>https://gotti.no-ip.org/maven/repository</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Maven only supports HTTPS now.