### PR TITLE
Reload status effects after adding in ModPack (serverpack)

### DIFF
--- a/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modsupport/packs/ModPacks.java
+++ b/modules/modlauncher/src/main/java/org/gotti/wurmunlimited/modsupport/packs/ModPacks.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -103,6 +104,8 @@ public class ModPacks {
 	// Track JarPacks created for a absolute pack file locations
 	private static HashMap<String, Object> addedPacks = new HashMap<>();
 
+	private static final ArrayList<FailedStatusEffect> failedStatusEffects = new ArrayList<>();
+
 	public static void preInit() {
 		try {
 			// com.wurmonline.client.resources.textures.PlayerTextureBuilder.loadImage(ResourceUrl, String)
@@ -125,7 +128,17 @@ public class ModPacks {
 			
 			classPool.get("com.wurmonline.client.resources.textures.PlayerTextureBuilderGL").getMethod("generateTexture", Descriptor.ofMethod(CtPrimitiveType.voidType, new CtClass[0])).instrument(modArmorDeriveEditor);
 			classPool.get("com.wurmonline.client.renderer.cell.PlayerTexture$PlayerBodyTextureLoader").getMethod("run", Descriptor.ofMethod(CtPrimitiveType.voidType, new CtClass[0])).instrument(modArmorDeriveEditor);
-			
+
+			classPool.get("com.wurmonline.client.renderer.gui.StatusEffectComponent")
+					.getMethod("addStatusEffect", Descriptor.ofMethod(CtPrimitiveType.voidType, new CtClass[]{CtPrimitiveType.longType, CtPrimitiveType.intType, CtPrimitiveType.intType, classPool.get("java.lang.String")}))
+					.instrument(new ExprEditor(){
+						@Override
+						public void edit(MethodCall m) throws CannotCompileException {
+							if(m.getMethodName().equals("updateSize")) {
+								m.replace("$_ = $proceed($$); if(info==null) org.gotti.wurmunlimited.modsupport.packs.ModPacks.addFailedStatusEffect(id, typeId, duration, name);");
+							}
+						}
+					});
 		} catch (NotFoundException | CannotCompileException e) {
 			throw new HookException(e);
 		}
@@ -315,6 +328,17 @@ public class ModPacks {
 				final HeadsUpDisplay hud = ReflectionUtil.getPrivateField(clientBase, ReflectionUtil.getField(WurmClientBase.class, "hud"));
 				Object statusEffectLibrary = StatusEffectXmlParser.loadXml();
 				ReflectionUtil.setPrivateField(hud.getStatusEffectComponent(), ReflectionUtil.getField(StatusEffectComponent.class, "statusEffectLibrary"), statusEffectLibrary);
+
+				// will send this many effects, since addStatusEffect might modify failedStatusEffects
+				final int numEffects = failedStatusEffects.size();
+				for (int i = 0; i < numEffects; ++i) {
+					FailedStatusEffect fSE = failedStatusEffects.remove(0);
+
+					int remainingDuration = (int)(fSE.sentAtSeconds + fSE.duration - System.currentTimeMillis()/1000);
+					if (remainingDuration > 0) {
+						hud.getStatusEffectComponent().addStatusEffect(fSE.id, fSE.typeId, remainingDuration, fSE.name);
+					}
+				}
 			} catch (NoSuchFieldException e) {
 				logger.log(Level.SEVERE, e.getMessage(), e);
 				throw new HookException(e);
@@ -379,4 +403,23 @@ public class ModPacks {
 		}
 	}
 
+	public static void addFailedStatusEffect(final long id, final int typeId, final int duration, final String name) {
+		failedStatusEffects.add(new FailedStatusEffect(System.currentTimeMillis()/1000, id, typeId, duration, name));
+	}
+
+	private static class FailedStatusEffect {
+		public final long sentAtSeconds;
+		public final long id;
+		public final int typeId;
+		public final int duration;
+		public final String name;
+
+		public FailedStatusEffect(final long sentAtSeconds, final long id, final int typeId, final int duration, final String name) {
+			this.sentAtSeconds = sentAtSeconds;
+			this.id = id;
+			this.typeId = typeId;
+			this.duration = duration;
+			this.name = name;
+		}
+	}
 }


### PR DESCRIPTION
309f555533056eb008631305c2f2b10126ac1d98 Makes it so the game reloads status effects (the visible icons in-game showing you have some kind of status effect, like priest penalties) after it adds in a new ModPack, similarly to how it reloads icons.

22707ffea54c11caec7e974ad7ca1cc26fc33a43 Allows mods to send status effects to the player before the required serverpack is loaded. Otherwise it would fail to find the custom status effect, and consequently not show anything to the player.

I made a mod that can be used to test how well custom status effects can be used. It's at https://github.com/Tyoda/StatusEffectTest

The first commit 309f555533056eb008631305c2f2b10126ac1d98 will allow later calls such as actions to use the custom status effects, such as [this](https://github.com/Tyoda/StatusEffectTest/blob/acdd8604ae42c7e5abf8fd51eb9a1915ca663f36/src/main/java/org/tyoda/wurm/statuseffecttest/ShortEffectAction.java#L61)

The second commit 22707ffea54c11caec7e974ad7ca1cc26fc33a43 will also allow sending a status effect on player login (or otherwise before the appropriate serverpack is loaded), and let it show after the serverpack has been loaded. Something like [this](https://github.com/Tyoda/StatusEffectTest/blob/acdd8604ae42c7e5abf8fd51eb9a1915ca663f36/src/main/java/org/tyoda/wurm/statuseffecttest/StatusEffectTest.java#L34)

Let me know if you have any questions or suggestions about the changes.